### PR TITLE
remove html from desktop notification

### DIFF
--- a/colcon_notification/event_handler/desktop_notification/__init__.py
+++ b/colcon_notification/event_handler/desktop_notification/__init__.py
@@ -87,5 +87,5 @@ class DesktopNotificationEventHandler(EventHandlerExtensionPoint):
             else:
                 notify(
                     '`{context.command_name} {context.args.verb_name}` '
-                    'with <i>stderr</i> output'.format_map(self.__dict__),
+                    'with stderr output'.format_map(self.__dict__),
                     os.getcwd(), Result.warning)


### PR DESCRIPTION
Since not all platforms support html tags in the message (e.g. macOS) this patch removes the italic tags around `stderr`.