### PR TITLE
catch exceptions form notify2 initialization

### DIFF
--- a/colcon_notification/desktop_notification/notify2.py
+++ b/colcon_notification/desktop_notification/notify2.py
@@ -1,10 +1,13 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+from colcon_core.logging import colcon_logger
 from colcon_core.plugin_system import satisfies_version
 from colcon_core.plugin_system import SkipExtensionException
 from colcon_notification.desktop_notification \
     import DesktopNotificationExtensionPoint
+
+logger = colcon_logger.getChild(__name__)
 
 
 class Notify2DesktopNotification(DesktopNotificationExtensionPoint):
@@ -30,7 +33,12 @@ class Notify2DesktopNotification(DesktopNotificationExtensionPoint):
         import notify2
 
         if not self._initialized:
-            notify2.init('colcon')
+            try:
+                notify2.init('colcon')
+            except Exception as e:
+                logger.debug(
+                    '"Failed to initialize notify2: {e}'.format_map(locals()))
+                return
             self._initialized = True
 
         if self._last_notification is None:


### PR DESCRIPTION
This happens when running a build without X11 (e.g. in a Docker container).