### PR TITLE
only enable status event handler by default when stdout is a tty-like device

### DIFF
--- a/colcon_notification/event_handler/status.py
+++ b/colcon_notification/event_handler/status.py
@@ -22,6 +22,8 @@ class StatusEventHandler(EventHandlerExtensionPoint):
     """
     Continuously update a status line.
 
+    The extension is only enabled by default if stdout is a tty-like device.
+
     The extension handles events of the following types:
     - :py:class:`colcon_core.event.output.StdoutLine`
     - :py:class:`colcon_core.event.job.JobEnded`
@@ -40,6 +42,9 @@ class StatusEventHandler(EventHandlerExtensionPoint):
         super().__init__()
         satisfies_version(
             EventHandlerExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+        self.enabled = sys.stdout.isatty()
+
         self._start_time = time.time()
         self._queued_count = 0
         self._running = {}


### PR DESCRIPTION
Commonly in non-tty environments like Jenkins the notification package shouldn't be installed. But in case it is disabling the status line by default makes more sense.