### PR TITLE
suppress traceback on Windows when notification can't be shown

### DIFF
--- a/colcon_notification/desktop_notification/win32.py
+++ b/colcon_notification/desktop_notification/win32.py
@@ -75,16 +75,21 @@ class NotificationWindow:
         # show the notification
         flags = win32gui.NIF_ICON | win32gui.NIF_MESSAGE | win32gui.NIF_TIP
         nid = (hwnd, 0, flags, win32con.WM_USER + 20, hicon, 'tooltip')
-        win32gui.Shell_NotifyIcon(
-            win32gui.NIM_ADD, nid)
-        win32gui.Shell_NotifyIcon(
-            win32gui.NIM_MODIFY, (
-                hwnd, 0, win32gui.NIF_INFO, win32con.WM_USER + 20, hicon,
-                'Balloon  tooltip', message, 200, title))
-
-        # wait a while before destroying the window
-        time.sleep(5)
-        win32gui.DestroyWindow(hwnd)
+        try:
+            win32gui.Shell_NotifyIcon(
+                win32gui.NIM_ADD, nid)
+            win32gui.Shell_NotifyIcon(
+                win32gui.NIM_MODIFY, (
+                    hwnd, 0, win32gui.NIF_INFO, win32con.WM_USER + 20, hicon,
+                    'Balloon  tooltip', message, 200, title))
+        except Exception as e:  # noqa: F841
+            logger.debug(
+                'Failed to show the notification: {e}'.format_map(locals()))
+        else:
+            # wait a while before destroying the window
+            time.sleep(5)
+        finally:
+            win32gui.DestroyWindow(hwnd)
 
     _wc = None
     _class_atom = None


### PR DESCRIPTION
This can happen when being ssh-ed into a Windows machine. The patch just suppresses the usual error message printed when a desktop notification extension raises an exception (see https://github.com/colcon/colcon-notification/blob/e51396d85c24c21a57077eebb8c9a0a315e2a4e5/colcon_notification/desktop_notification/__init__.py#L105-L116). This is similar to what we already do for other desktop notifications, e.g.: https://github.com/colcon/colcon-notification/blob/e51396d85c24c21a57077eebb8c9a0a315e2a4e5/colcon_notification/desktop_notification/notify2.py#L36-L41