### PR TITLE
add No-Python2 flag to stdeb.cfg to avoid making Python 2 releases by accident

### DIFF
--- a/stdeb.cfg
+++ b/stdeb.cfg
@@ -1,4 +1,5 @@
 [colcon-notification]
+No-Python2:
 Depends3: python3-colcon-core, python3-notify2
 Suite: xenial bionic stretch buster
 X-Python3-Version: >= 3.5


### PR DESCRIPTION
Same as colcon/colcon-core#165.