### PR TITLE
Disable title handler for dumb terminals

### DIFF
--- a/colcon_notification/event_handler/terminal_title.py
+++ b/colcon_notification/event_handler/terminal_title.py
@@ -1,6 +1,7 @@
 # Copyright 2016-2018 Dirk Thomas
 # Licensed under the Apache License, Version 2.0
 
+import os
 import platform
 import sys
 
@@ -14,6 +15,8 @@ from colcon_core.plugin_system import satisfies_version
 class TerminalTitleEventHandler(EventHandlerExtensionPoint):
     """
     Show status in the terminal title.
+
+    The extension is only enabled by default if stdout is a tty-like device.
 
     The extension handles events of the following types:
     - :py:class:`colcon_core.event.job.JobQueued`
@@ -29,6 +32,10 @@ class TerminalTitleEventHandler(EventHandlerExtensionPoint):
         super().__init__()
         satisfies_version(
             EventHandlerExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+        # Setting the title does not work in dumb terminals, i.e., Emacs
+        self.enabled = (sys.stdout.isatty() and os.getenv('TERM') != 'dumb')
+
         self._queued_count = 0
         self._ongoing_count = 0
         self._ended_count = 0

--- a/colcon_notification/event_handler/terminal_title.py
+++ b/colcon_notification/event_handler/terminal_title.py
@@ -16,7 +16,8 @@ class TerminalTitleEventHandler(EventHandlerExtensionPoint):
     """
     Show status in the terminal title.
 
-    The extension is only enabled by default if stdout is a tty-like device.
+    The extension is only enabled by default if stdout is a tty-like device
+    and not a dumb terminal.
 
     The extension handles events of the following types:
     - :py:class:`colcon_core.event.job.JobQueued`
@@ -34,7 +35,7 @@ class TerminalTitleEventHandler(EventHandlerExtensionPoint):
             EventHandlerExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
 
         # Setting the title does not work in dumb terminals, i.e., Emacs
-        self.enabled = (sys.stdout.isatty() and os.getenv('TERM') != 'dumb')
+        self.enabled = sys.stdout.isatty() and os.getenv('TERM') != 'dumb'
 
         self._queued_count = 0
         self._ongoing_count = 0

--- a/test/spell_check.words
+++ b/test/spell_check.words
@@ -7,6 +7,7 @@ currentframe
 darwin
 debian
 defaultsize
+emacs
 fedd
 foreach
 getpid


### PR DESCRIPTION
This is a small fix for the noisy output in dumb terminals and non-TTYs.

This event handler is only enabled when the output is a TTY and the terminal is not `dumb`.