### PR TITLE
Use verb name from context in TerminalTitleEventHandler

### DIFF
--- a/colcon_notification/event_handler/terminal_title.py
+++ b/colcon_notification/event_handler/terminal_title.py
@@ -58,7 +58,7 @@ class TerminalTitleEventHandler(EventHandlerExtensionPoint):
             self._update()
 
     def _update(self):
-        message = '{context.command_name} build ' \
+        message = '{context.command_name} {context.args.verb_name} ' \
             '[{_ended_count}/{_queued_count} done] ' \
             '[{_ongoing_count} ongoing]'.format_map(self.__dict__)
 


### PR DESCRIPTION
Instead of just 'build'

Fixes #38 