### PR TITLE
use more actively maintained pip pywin32

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ install:
   - "%PYTHON%\\python.exe -m pip install -U setuptools"
   # install_requires
   - "%PYTHON%\\python.exe -m pip install -U git+https://github.com/colcon/colcon-core"
-  - "%PYTHON%\\python.exe -m pip install -U pypiwin32"
+  - "%PYTHON%\\python.exe -m pip install -U pywin32"
   # tests_require
   - "%PYTHON%\\python.exe -m pip install -U flake8-blind-except flake8-builtins flake8-class-newline flake8-comprehensions flake8-deprecated flake8-docstrings flake8-quotes pep8-naming pylint pytest pytest-cov scspell3k"
 build: off

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ keywords = colcon
 install_requires =
   colcon-core>=0.3.7
   notify2; sys_platform == 'linux'
-  pypiwin32; sys_platform == 'win32'
+  pywin32; sys_platform == 'win32'
 packages = find:
 tests_require =
   flake8>=3.6.0


### PR DESCRIPTION
Based on the release history, it seems that [pywin32](https://github.com/mhammond/pywin32) moved its PyPi packages from [`pypiwin32`](https://pypi.org/project/pypiwin32/#description) to [`pywin32`](https://pypi.org/project/pywin32/). I am proposing to depend on the more actively maintained pip in `setup.cfg`.