### PR TITLE
fix transient hint when DBus reports different signature

### DIFF
--- a/colcon_notification/desktop_notification/notify2.py
+++ b/colcon_notification/desktop_notification/notify2.py
@@ -44,7 +44,7 @@ class Notify2DesktopNotification(DesktopNotificationExtensionPoint):
         if self._last_notification is None:
             self._last_notification = notify2.Notification(
                 title, message=message, icon=icon_path)
-            self._last_notification.set_hint('transient', True)
+            self._last_notification.set_hint_byte('transient', b'\x01')
         else:
             self._last_notification.update(
                 title, message=message, icon=icon_path)


### PR DESCRIPTION
Follow up of #46. Based on this question: https://answers.ros.org/question/362449/colcon-builds-but-gives-errordbusconnectionunable-to-set-arguments/

If DBus reports the signature as `susssasa{ss}i` the current code results in a `TypeError: Expected a string or unicode object` since the hint value isn't a string / `s`. It does work when the signature is reported as `susssasa{sv}i` which allows a variant type for the hint value.

This patch uses `set_hint_byte()` which hopefully works around the problem.