### PR TITLE
Be test-runner friendly by only decorating stdout/stderr if status line enabled.

### DIFF
--- a/colcon_notification/event_handler/status.py
+++ b/colcon_notification/event_handler/status.py
@@ -55,20 +55,21 @@ class StatusEventHandler(EventHandlerExtensionPoint):
         # pattern to match progress indicator in e.g. make
         self._progress_pattern = re.compile(r'^\[(  \d| \d\d|1\d\d)%\] ')
 
-        # decorate write methods for stdout / stderr
-        # to clear the last status line before other output
-        sys.stdout.write = self._write_and_last_clear_status_line(
-            sys.stdout.write)
-        sys.stdout.buffer.write = self._write_and_last_clear_status_line(
-            sys.stdout.buffer.write)
-        sys.stderr.write = self._write_and_last_clear_status_line(
-            sys.stderr.write)
-        sys.stderr.buffer.write = self._write_and_last_clear_status_line(
-            sys.stderr.buffer.write)
-        self._last_status_line_length = None
+        if self.enabled:
+            # decorate write methods for stdout / stderr
+            # to clear the last status line before other output
+            sys.stdout.write = self._write_and_last_clear_status_line(
+                sys.stdout.write)
+            sys.stdout.buffer.write = self._write_and_last_clear_status_line(
+                sys.stdout.buffer.write)
+            sys.stderr.write = self._write_and_last_clear_status_line(
+                sys.stderr.write)
+            sys.stderr.buffer.write = self._write_and_last_clear_status_line(
+                sys.stderr.buffer.write)
+            self._last_status_line_length = None
 
-        # register exit handle to ensure the last status line is cleared
-        atexit.register(self._clear_last_status_line)
+            # register exit handle to ensure the last status line is cleared
+            atexit.register(self._clear_last_status_line)
 
     def _write_and_last_clear_status_line(self, func):
         def wrapped_func(*args, **kwargs):


### PR DESCRIPTION
I have an in-progress colcon verb extension and I have a test for it which calls it via `colcon_core.commands.verb_main`. This works on its own and when run via `nose`, but fails with with an error when run via `coverage`, I guess because `sys.stdout` and `sys.stderr` are being overwritten in that environment to be StringIO objects which don't have the buffer attribute:

```
colcon.colcon_core.plugin_system: ERROR: Exception instantiating extension 'colcon_core.event_handler.status': '_io.StringIO' object has no attribute 'buffer'
Traceback (most recent call last):
  File "/home/administrator/colcon-env/lib/python3.8/site-packages/colcon_core/plugin_system.py", line 60, in _instantiate_extension
    extension_instance = extension_class()
  File "/home/administrator/colcon-env/lib/python3.8/site-packages/colcon_notification/event_handler/status.py", line 63, in __init__
    sys.stdout.buffer.write)
AttributeError: '_io.StringIO' object has no attribute 'buffer
```

It ends up being a bit of a cascade, because colcon actually traps this exception and carries on, with colcon-notification in a half-initialized state, so later on there are other failures from the rest of the constructor having not executed:

```
colcon.colcon_core.event_reactor: ERROR: Exception in event handler extension 'summary': 'StatusEventHandler' object has no attribute '_last_status_line_length'
Traceback (most recent call last):
  File "/home/administrator/colcon-env/lib/python3.8/site-packages/colcon_core/event_reactor.py", line 78, in _notify_observers
    retval = observer(event)
  File "/home/administrator/colcon-env/lib/python3.8/site-packages/colcon_output/event_handler/summary.py", line 65, in __call__
    self._print_summary()
  File "/home/administrator/colcon-env/lib/python3.8/site-packages/colcon_output/event_handler/summary.py", line 69, in _print_summary
    print()
  File "/home/administrator/colcon-env/lib/python3.8/site-packages/colcon_notification/event_handler/status.py", line 75, in wrapped_func
    self._clear_last_status_line()
  File "/home/administrator/colcon-env/lib/python3.8/site-packages/colcon_notification/event_handler/status.py", line 80, in _clear_last_status_line
    if self._last_status_line_length is not None:
AttributeError: 'StatusEventHandler' object has no attribute '_last_status_line_length
```

This change addresses the issue by not trying to decorate in the non-tty case.