### PR TITLE
suppress deprecation warning in flake8

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,8 @@ share/colcon_notification/colcon-terminal-notifier.app/Contents/Resources/en.lpr
 [tool:pytest]
 filterwarnings =
     error
+    # Suppress deprecation warning in flake8
+    ignore:SelectableGroups dict interface is deprecated::flake8
 junit_suite_name = colcon-notification
 
 [options.entry_points]


### PR DESCRIPTION
Introduced by python/importlib_metadata # 298.