### PR TITLE
Suppress DeprecationWarning within pytest when testing

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -69,6 +69,7 @@ filterwarnings =
     # Suppress deprecation warnings in other packages
     ignore:lib2to3 package is deprecated::scspell
     ignore:SelectableGroups dict interface is deprecated::flake8
+    ignore:The 'asyncio_mode' default value will change to 'strict' in future:DeprecationWarning:pytest
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated::pyreadline
 junit_suite_name = colcon-notification
 


### PR DESCRIPTION
This issue is likely fixed in more recent releases of pytest-asyncio, but not all of our supported platforms have a system package new enough to contain the change.