### PR TITLE
Fix name of the colcon-terminal-notifier in search path

### DIFF
--- a/colcon_notification/desktop_notification/terminal_notifier.py
+++ b/colcon_notification/desktop_notification/terminal_notifier.py
@@ -97,7 +97,7 @@ def _get_prefix_path(path):
 
 def _get_app_path(prefix_path):
     app_path = prefix_path / 'share' / 'colcon_notification' / \
-        'colcon_terminal_notifier.app'
+        'colcon-terminal-notifier.app'
     if app_path.exists():
         return app_path
     return None


### PR DESCRIPTION
I am on Mac OS and was trying to install ROS2 using colcon. I faced this issue where no matter the version I downloaded or upgraded, it kept erroring at `[12.107s] ERROR:colcon.colcon_notification.desktop_notification.terminal_notifier:Could not find the colcon-terminal-notifier.app in the install prefix '/Library/Frameworks/Python.framework/Versions/3.11'` 

When I downloaded the zipped package for colcon-notifications, I noticed the difference in the names. It was searching for the name with underscores and hence was not able to find the actual file that had hyphens instead. 
