### PR TITLE
Set proper return value from WM_DESTROY message on Windows

### DIFF
--- a/colcon_notification/desktop_notification/win32.py
+++ b/colcon_notification/desktop_notification/win32.py
@@ -124,3 +124,5 @@ class NotificationWindow:
                 'Failed to delete the notification handle: {e}'
                 .format_map(locals()))
         win32gui.PostQuitMessage(0)
+
+        return 0


### PR DESCRIPTION
The documented return value for this message is an integer return code.

https://learn.microsoft.com/en-us/windows/win32/winmsg/wm-destroy#return-value

Closes #64 