### PR TITLE
Default to 'off' when invoked on an obviously SSH shell

### DIFF
--- a/colcon_notification/event_handler/desktop_notification/__init__.py
+++ b/colcon_notification/event_handler/desktop_notification/__init__.py
@@ -32,6 +32,15 @@ class DesktopNotificationEventHandler(EventHandlerExtensionPoint):
         super().__init__()
         satisfies_version(
             EventHandlerExtensionPoint.EXTENSION_POINT_VERSION, '^1.0')
+
+        # default to disabled over SSH
+        self.enabled = not any(
+            os.getenv(var) for var in (
+                'SSH_TTY',
+                'SSH_CLIENT',
+                'SSH_CONNECTION',
+            ))
+
         self._any_stderr_output = False
         self._any_test_failure = False
         self._failed = []


### PR DESCRIPTION
While this doesn't determine if invoked over an SSH shell with 100% certainty (like if sudo is involved), it's a trivial hint that the user probably doesn't want desktop notifications enabled.

Note that the behavior can still be specified either way, we're just changing the default behavior here.

Inspired by: [#31 (comment)](https://github.com/colcon/colcon-notification/issues/31#issuecomment-1853191258)